### PR TITLE
Prevent Fossa from uploading scan results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,17 +39,13 @@ jobs:
         env_vars: OS,GO
     - name: Add GOPATH to GITHUB_ENV
       run: echo "GOPATH=$(go env GOPATH)" >>"$GITHUB_ENV"
-    - name: Scan and upload FOSSA data (Linux/Mac)
+    - name: Scan FOSSA data (Linux/Mac)
       if: github.ref == 'refs/heads/master' && matrix.platform != 'windows-latest'
       run: |
         curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash
-        fossa analyze
-      env:
-        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-    - name: Scan and upload FOSSA data (Windows)
+        fossa analyze --output
+    - name: Scan FOSSA data (Windows)
       if: github.ref == 'refs/heads/master' && matrix.platform == 'windows-latest'
       run: |
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install.ps1'))
-        C:\ProgramData\fossa-cli\fossa.exe analyze
-      env:
-        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+        C:\ProgramData\fossa-cli\fossa.exe analyze --output


### PR DESCRIPTION
Pass --output arg to prevent it from uploading data to the Fossa API.

From the Fossa CLI output:

> Running `fossa analyze` performs a dependency analysis and uploads the result
> to FOSSA. To run an analysis without uploading results, run:
>
>     fossa analyze --output
>

See master build failure: https://github.com/Shopify/v8go/runs/2521544350?check_suite_focus=true