### PR TITLE
Introduce v8go.Profiler

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -4,7 +4,7 @@
 
 package v8go
 
-//go:generate clang-format -i --verbose -style=Chromium v8go.h v8go.cc
+//go:generate clang-format -i --verbose -style=Chromium v8go.h v8go.cc v8go-profiler.h  v8go-profiler.cc
 
 // #cgo CXXFLAGS: -fno-rtti -fpic -std=c++14 -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH -I${SRCDIR}/deps/include
 // #cgo LDFLAGS: -pthread -lv8

--- a/profiler.go
+++ b/profiler.go
@@ -1,0 +1,50 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package v8go
+
+// #include <stdlib.h>
+// #include "v8go.h"
+import "C"
+
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+type Profiler struct {
+	ptr C.ProfilerPtr
+	ctx *Context
+}
+
+func NewProfiler(ctx *Context) (*Profiler, error) {
+	if ctx == nil {
+		return nil, errors.New("v8go: failed to create new Profiler: Context cannot be <nil>")
+	}
+
+	profiler := &Profiler{
+		ptr: C.NewProfiler(ctx.ptr),
+		ctx: ctx,
+	}
+	runtime.SetFinalizer(profiler, (*Profiler).finalizer)
+
+	return profiler, nil
+}
+
+func (p *Profiler) Start() {
+	C.ProfilerStart(p.ptr)
+}
+
+func (p *Profiler) Stop() string {
+	s := C.ProfilerStop(p.ptr)
+	defer C.free(unsafe.Pointer(s))
+	return C.GoString(s)
+}
+
+func (p *Profiler) finalizer() {
+	C.ProfilerFree(p.ptr)
+	p.ptr = nil
+	runtime.SetFinalizer(p, nil)
+}

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -1,0 +1,22 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package v8go_test
+
+import (
+	"testing"
+
+	"github.com/Shopify/v8go"
+)
+
+func TestProfiler(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := v8go.NewContext()
+	profiler, _ := v8go.NewProfiler(ctx)
+
+	profiler.Start()
+	ctx.RunScript("const foo = {}; foo", "")
+	profiler.Stop()
+}

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -18,5 +18,11 @@ func TestProfiler(t *testing.T) {
 
 	profiler.Start()
 	ctx.RunScript("const foo = {}; foo", "")
-	profiler.Stop()
+	jsonProfile, err := profiler.Stop()
+	if err != nil {
+		t.Errorf("Invalid json profile: %v", err)
+	}
+	if len(jsonProfile) == 0 {
+		t.Error("Missing profile data")
+	}
 }

--- a/profiler_test.go
+++ b/profiler_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestProfiler(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	ctx, _ := v8go.NewContext()
 	profiler, _ := v8go.NewProfiler(ctx)

--- a/v8go-internal.h
+++ b/v8go-internal.h
@@ -1,0 +1,15 @@
+#ifndef V8GO_INTERNAL_H
+#define V8GO_INTERNAL_H
+
+#if defined(__MINGW32__) || defined(__MINGW64__)
+// MinGW header files do not implicitly include windows.h
+struct _EXCEPTION_POINTERS;
+#endif
+
+#include "libplatform/libplatform.h"
+#include "v8.h"
+#include "v8-inspector.h"
+
+#include "v8go.h"
+
+#endif

--- a/v8go-profiler.cc
+++ b/v8go-profiler.cc
@@ -1,7 +1,7 @@
 #include <string>
 #include <iostream>
 
-#include <libplatform/libplatform.h>
+#include "v8go-internal.h"
 #include "v8go-profiler.h"
 
 InspectorFrontend::InspectorFrontend(v8::Local<v8::Context> context) {

--- a/v8go-profiler.cc
+++ b/v8go-profiler.cc
@@ -1,0 +1,64 @@
+#include <string>
+#include <iostream>
+
+#include <libplatform/libplatform.h>
+#include "v8go-profiler.h"
+
+InspectorFrontend::InspectorFrontend(v8::Local<v8::Context> context) {
+  isolate_ = context->GetIsolate();
+  context_.Reset(isolate_, context);
+}
+
+void InspectorFrontend::sendResponse(int callId, std::unique_ptr<v8_inspector::StringBuffer> buffer) {
+  saveResponse(buffer->string());
+}
+
+void InspectorFrontend::sendNotification(std::unique_ptr<v8_inspector::StringBuffer> buffer) {
+  saveResponse(buffer->string());
+}
+
+void InspectorFrontend::saveResponse(v8_inspector::StringView view) {
+  v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::String> encoded =
+      (view.is8Bit()
+           ? v8::String::NewFromOneByte(
+                 isolate_,
+                 reinterpret_cast<const uint8_t*>(view.characters8()),
+                 v8::NewStringType::kNormal, view.length())
+           : v8::String::NewFromTwoByte(
+                 isolate_,
+                 reinterpret_cast<const uint16_t*>(view.characters16()),
+                 v8::NewStringType::kNormal, view.length()))
+          .ToLocalChecked();
+
+  v8::String::Utf8Value utf8(isolate_, encoded);
+  response.assign(*utf8, utf8.length());
+}
+
+Profiler::Profiler(v8::Local<v8::Context> context) {
+  isolate_ = context->GetIsolate();
+
+  inspector_ = v8_inspector::V8Inspector::create(isolate_, new InspectorClient());
+
+  frontend_ = std::unique_ptr<InspectorFrontend>(new InspectorFrontend(context));
+
+  session_ = inspector_->connect(1, frontend_.get(), v8_inspector::StringView());
+
+  inspector_->contextCreated(v8_inspector::V8ContextInfo(context, 1, v8_inspector::StringView()));
+}
+
+void Profiler::start() {
+  send_message("{\"id\":0,\"method\":\"Profiler.enable\"}");
+  send_message("{\"id\":1,\"method\":\"Profiler.start\"}");
+}
+
+std::string Profiler::stop() {
+  send_message("{\"id\":2,\"method\":\"Profiler.stop\"}");
+  return frontend_->response;
+}
+
+void Profiler::send_message(std::string msg) {
+  v8_inspector::StringView message_view(reinterpret_cast<const uint8_t *>(msg.c_str()), msg.length());
+  frontend_->response.clear();
+  session_->dispatchProtocolMessage(message_view);
+}

--- a/v8go-profiler.cc
+++ b/v8go-profiler.cc
@@ -4,22 +4,54 @@
 #include <libplatform/libplatform.h>
 #include "v8go-profiler.h"
 
+InspectorFrontend::InspectorFrontend(v8::Local<v8::Context> context) {
+  isolate_ = context->GetIsolate();
+  context_.Reset(isolate_, context);
+}
+
 void InspectorFrontend::sendResponse(int callId, std::unique_ptr<v8_inspector::StringBuffer> buffer) {
-  saveResponse(buffer->string());
+  response_ = std::move(buffer);
 }
 
 void InspectorFrontend::sendNotification(std::unique_ptr<v8_inspector::StringBuffer> buffer) {
-  saveResponse(buffer->string());
+  response_ = std::move(buffer);
 }
 
-void InspectorFrontend::saveResponse(v8_inspector::StringView view) {
-  responses.push_back(view);
+void InspectorFrontend::clearResponse() {
+  response_ = nullptr;
+}
+
+const char* InspectorFrontend::cStringResponse(int *length_ptr) {
+  v8_inspector::StringView view(response_->string());
+  v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::String> encoded =
+      (view.is8Bit()
+           ? v8::String::NewFromOneByte(
+                 isolate_,
+                 reinterpret_cast<const uint8_t*>(view.characters8()),
+                 v8::NewStringType::kNormal, view.length())
+           : v8::String::NewFromTwoByte(
+                 isolate_,
+                 reinterpret_cast<const uint16_t*>(view.characters16()),
+                 v8::NewStringType::kNormal, view.length()))
+          .ToLocalChecked();
+  v8::String::Utf8Value utf8(isolate_, encoded);
+  int length = utf8.length();
+  char *response_string = (char *)malloc(length);
+  if (!response_string)  {
+    *length_ptr = 0;
+  } else {
+    *length_ptr = length;
+    memcpy((void*)response_string, *utf8, length);
+  }
+
+  return response_string;
 }
 
 Profiler::Profiler(v8::Local<v8::Context> context) {
-  isolate_ = context->GetIsolate();
-  inspector_ = v8_inspector::V8Inspector::create(isolate_, new InspectorClient());
-  frontend_ = std::unique_ptr<InspectorFrontend>(new InspectorFrontend());
+  isolate = context->GetIsolate();
+  inspector_ = v8_inspector::V8Inspector::create(isolate, new InspectorClient());
+  frontend_ = std::unique_ptr<InspectorFrontend>(new InspectorFrontend(context));
   session_ = inspector_->connect(1, frontend_.get(), v8_inspector::StringView());
   inspector_->contextCreated(v8_inspector::V8ContextInfo(context, 1, v8_inspector::StringView()));
 }
@@ -29,30 +61,13 @@ void Profiler::start() {
   send_message("{\"id\":1,\"method\":\"Profiler.start\"}");
 }
 
-std::string Profiler::stop() {
+const char *Profiler::stop(int *length) {
   send_message("{\"id\":2,\"method\":\"Profiler.stop\"}");
-
-  // v8::HandleScope handle_scope(isolate_);
-  // v8::Local<v8::String> encoded =
-  //     (view.is8Bit()
-  //          ? v8::String::NewFromOneByte(
-  //                isolate_,
-  //                reinterpret_cast<const uint8_t*>(view.characters8()),
-  //                v8::NewStringType::kNormal, view.length())
-  //          : v8::String::NewFromTwoByte(
-  //                isolate_,
-  //                reinterpret_cast<const uint16_t*>(view.characters16()),
-  //                v8::NewStringType::kNormal, view.length()))
-  //         .ToLocalChecked();
-
-  // v8::String::Utf8Value utf8(isolate_, encoded);
-  // response.assign(*utf8, utf8.length());
-
-  return std::string("Hello");
+  return frontend_->cStringResponse(length);
 }
 
 void Profiler::send_message(std::string msg) {
   v8_inspector::StringView message_view(reinterpret_cast<const uint8_t *>(msg.c_str()), msg.length());
-  frontend_->responses.clear();
+  frontend_->clearResponse();
   session_->dispatchProtocolMessage(message_view);
 }

--- a/v8go-profiler.h
+++ b/v8go-profiler.h
@@ -1,0 +1,44 @@
+#ifndef V8GO_PROFILER_H
+#define V8GO_PROFILER_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <v8-inspector.h>
+#include <v8.h>
+
+class InspectorFrontend final : public v8_inspector::V8Inspector::Channel {
+ public:
+  InspectorFrontend(v8::Local<v8::Context> context);
+  void sendResponse(int callId, std::unique_ptr<v8_inspector::StringBuffer> buffer) override;
+  void sendNotification(std::unique_ptr<v8_inspector::StringBuffer> buffer) override;
+  void flushProtocolNotifications() override {};
+
+  std::string response;
+
+ private:
+  void saveResponse(v8_inspector::StringView view);
+
+  v8::Isolate* isolate_;
+  v8::Global<v8::Context> context_;
+};
+
+class InspectorClient : public v8_inspector::V8InspectorClient {
+};
+
+class Profiler final {
+ public:
+  Profiler(v8::Local<v8::Context> context);
+
+  void start();
+  std::string stop();
+
+ private:
+  void send_message(std::string msg);
+
+  std::unique_ptr<v8_inspector::V8Inspector> inspector_;
+  std::unique_ptr<v8_inspector::V8InspectorSession> session_;
+  std::unique_ptr<InspectorFrontend> frontend_;
+  v8::Isolate* isolate_;
+};
+
+#endif  // V8GO_PROFILER_H

--- a/v8go-profiler.h
+++ b/v8go-profiler.h
@@ -8,15 +8,19 @@
 
 class InspectorFrontend final : public v8_inspector::V8Inspector::Channel {
  public:
-  InspectorFrontend() {}
+  InspectorFrontend(v8::Local<v8::Context> context);
   void sendResponse(int callId, std::unique_ptr<v8_inspector::StringBuffer> buffer) override;
   void sendNotification(std::unique_ptr<v8_inspector::StringBuffer> buffer) override;
   void flushProtocolNotifications() override {};
 
-  std::vector<v8_inspector::StringView> responses;
+  void clearResponse();
+  const char* cStringResponse(int *length);
 
  private:
-  void saveResponse(v8_inspector::StringView view);
+
+  std::unique_ptr<v8_inspector::StringBuffer> response_;
+  v8::Isolate* isolate_;
+  v8::Global<v8::Context> context_;
 };
 
 class InspectorClient : public v8_inspector::V8InspectorClient {
@@ -27,7 +31,9 @@ class Profiler final {
   Profiler(v8::Local<v8::Context> context);
 
   void start();
-  std::string stop();
+  const char *stop(int *length);
+
+  v8::Isolate* isolate;
 
  private:
   void send_message(std::string msg);
@@ -35,7 +41,6 @@ class Profiler final {
   std::unique_ptr<v8_inspector::V8Inspector> inspector_;
   std::unique_ptr<v8_inspector::V8InspectorSession> session_;
   std::unique_ptr<InspectorFrontend> frontend_;
-  v8::Isolate* isolate_;
 };
 
 #endif  // V8GO_PROFILER_H

--- a/v8go-profiler.h
+++ b/v8go-profiler.h
@@ -8,18 +8,15 @@
 
 class InspectorFrontend final : public v8_inspector::V8Inspector::Channel {
  public:
-  InspectorFrontend(v8::Local<v8::Context> context);
+  InspectorFrontend() {}
   void sendResponse(int callId, std::unique_ptr<v8_inspector::StringBuffer> buffer) override;
   void sendNotification(std::unique_ptr<v8_inspector::StringBuffer> buffer) override;
   void flushProtocolNotifications() override {};
 
-  std::string response;
+  std::vector<v8_inspector::StringView> responses;
 
  private:
   void saveResponse(v8_inspector::StringView view);
-
-  v8::Isolate* isolate_;
-  v8::Global<v8::Context> context_;
 };
 
 class InspectorClient : public v8_inspector::V8InspectorClient {

--- a/v8go.cc
+++ b/v8go.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "v8go.h"
+#include "v8go-profiler.h"
 
 #include <stdio.h>
 
@@ -1176,6 +1177,30 @@ ValuePtr ExceptionTypeError(IsolatePtr iso_ptr, const char* message) {
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
       iso, Exception::TypeError(msg));
   return static_cast<ValuePtr>(val);
+}
+
+/********** Profiler **********/
+
+ProfilerPtr NewProfiler(ContextPtr ctx_ptr) {
+  LOCAL_CONTEXT(ctx_ptr);
+  Profiler* profiler = new Profiler(local_ctx);
+  return static_cast<ProfilerPtr>(profiler);
+}
+
+void ProfilerStart(ProfilerPtr ptr) {
+  Profiler* profiler = static_cast<Profiler*>(ptr);
+  profiler->start();
+}
+
+const char* ProfilerStop(ProfilerPtr ptr) {
+  Profiler* profiler = static_cast<Profiler*>(ptr);
+  std::string response = profiler->stop();
+  char* cstr = strcpy(new char[response.length() + 1], response.c_str());
+  return cstr;
+}
+
+void ProfilerFree(ProfilerPtr ptr) {
+  delete static_cast<Profiler*>(ptr);
 }
 
 /********** v8::V8 **********/

--- a/v8go.cc
+++ b/v8go.cc
@@ -1189,14 +1189,14 @@ ProfilerPtr NewProfiler(ContextPtr ctx_ptr) {
 
 void ProfilerStart(ProfilerPtr ptr) {
   Profiler* profiler = static_cast<Profiler*>(ptr);
+  Locker lock(profiler->isolate);
   profiler->start();
 }
 
-const char* ProfilerStop(ProfilerPtr ptr) {
+const char* ProfilerStop(ProfilerPtr ptr, int *length) {
   Profiler* profiler = static_cast<Profiler*>(ptr);
-  std::string response = profiler->stop();
-  char* cstr = strcpy(new char[response.length() + 1], response.c_str());
-  return cstr;
+  Locker lock(profiler->isolate);
+  return profiler->stop(length);
 }
 
 void ProfilerFree(ProfilerPtr ptr) {

--- a/v8go.cc
+++ b/v8go.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "v8go.h"
+#include "v8go-internal.h"
 #include "v8go-profiler.h"
 
 #include <stdio.h>
@@ -13,14 +13,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-
-#if defined(__MINGW32__) || defined(__MINGW64__)
-// MinGW header files do not implicitly include windows.h
-struct _EXCEPTION_POINTERS;
-#endif
-
-#include "libplatform/libplatform.h"
-#include "v8.h"
 
 using namespace v8;
 

--- a/v8go.h
+++ b/v8go.h
@@ -185,7 +185,7 @@ extern ValuePtr ExceptionTypeError(IsolatePtr iso_ptr, const char* message);
 
 extern ProfilerPtr NewProfiler(ContextPtr ctx);
 extern void ProfilerStart(ProfilerPtr ptr);
-extern const char* ProfilerStop(ProfilerPtr ptr);
+extern const char* ProfilerStop(ProfilerPtr ptr, int *length);
 extern void ProfilerFree(ProfilerPtr ptr);
 
 const char* Version();

--- a/v8go.h
+++ b/v8go.h
@@ -16,6 +16,7 @@ typedef void* IsolatePtr;
 typedef void* ContextPtr;
 typedef void* ValuePtr;
 typedef void* TemplatePtr;
+typedef void* ProfilerPtr;
 
 typedef struct {
   const char* msg;
@@ -181,6 +182,11 @@ extern ValuePtr ExceptionReferenceError(IsolatePtr iso_ptr,
                                         const char* message);
 extern ValuePtr ExceptionSyntaxError(IsolatePtr iso_ptr, const char* message);
 extern ValuePtr ExceptionTypeError(IsolatePtr iso_ptr, const char* message);
+
+extern ProfilerPtr NewProfiler(ContextPtr ctx);
+extern void ProfilerStart(ProfilerPtr ptr);
+extern const char* ProfilerStop(ProfilerPtr ptr);
+extern void ProfilerFree(ProfilerPtr ptr);
 
 const char* Version();
 extern void SetFlags(const char* flags);


### PR DESCRIPTION
Currently crashes w/

```
#
# Fatal error in HandleScope::HandleScope
# Entering the V8 API without proper locking in place
#

SIGILL: illegal instruction
```

Pretty sure because I'm using a `Local<Context>` instead of a `Persistent` one in the Profiler.