### PR TITLE
Exposing UnboundScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for setting and getting internal fields for template object instances
 - Support for CPU profiling
 - Add V8 build for Apple Silicon
+- Support for compiling a context-dependent UnboundScript which can be run in any context of the isolate it was compiled in.
+- Support for creating a code cache from an UnboundScript which can be used to create an UnboundScript in other isolates
+to run a pre-compiled script in new contexts.
 
 ### Changed
 - Removed error return value from NewIsolate which never fails
@@ -23,8 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed error return value from Context.Isolate() which never fails
 - Removed error return value from NewObjectTemplate and NewFunctionTemplate. Panic if given a nil argument.
 - Function Call accepts receiver as first argument.
-- Changed ctx.RunScript to accept a cached data argument available by compiling a script with iso.CompileScript.
-- Introduced ctx.CompileAndRun which accepts the same arguments and behaves the same as ctx.RunScript _used to_.
 
 ### Fixed
 - Add some missing error propagation

--- a/context.go
+++ b/context.go
@@ -82,30 +82,16 @@ func (c *Context) Isolate() *Isolate {
 	return c.iso
 }
 
-// CompileAndRun executes the source JavaScript; origin (a.k.a. filename) provides a
+// RunScript executes the source JavaScript; origin (a.k.a. filename) provides a
 // reference for the script and used in the stack trace if there is an error.
 // error will be of type `JSError` if not nil.
-func (c *Context) CompileAndRun(source string, origin string) (*Value, error) {
+func (c *Context) RunScript(source string, origin string) (*Value, error) {
 	cSource := C.CString(source)
 	cOrigin := C.CString(origin)
 	defer C.free(unsafe.Pointer(cSource))
 	defer C.free(unsafe.Pointer(cOrigin))
 
-	rtn := C.CompileAndRun(c.ptr, cSource, cOrigin)
-	return valueResult(c, rtn)
-}
-
-// RunScript executes the source JavaScript using the compiled source;
-// origin (a.k.a. filename) provides a reference for the script and used in
-// the stack trace if there is an error.
-// error will be of type `JSError` if not nil.
-func (c *Context) RunScript(source string, compiledSource []byte, origin string) (*Value, error) {
-	cSource := C.CString(source)
-	cOrigin := C.CString(origin)
-	defer C.free(unsafe.Pointer(cSource))
-	defer C.free(unsafe.Pointer(cOrigin))
-
-	rtn := C.RunScript(c.ptr, cSource, (*C.uchar)(unsafe.Pointer(&compiledSource[0])), C.int(len(compiledSource)), cOrigin)
+	rtn := C.RunScript(c.ptr, cSource, cOrigin)
 	return valueResult(c, rtn)
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -18,21 +18,21 @@ func TestContextExec(t *testing.T) {
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
-	ctx.CompileAndRun(`const add = (a, b) => a + b`, "add.js")
-	val, _ := ctx.CompileAndRun(`add(3, 4)`, "main.js")
+	ctx.RunScript(`const add = (a, b) => a + b`, "add.js")
+	val, _ := ctx.RunScript(`add(3, 4)`, "main.js")
 	rtn := val.String()
 	if rtn != "7" {
 		t.Errorf("script returned an unexpected value: expected %q, got %q", "7", rtn)
 	}
 
-	_, err := ctx.CompileAndRun(`add`, "func.js")
+	_, err := ctx.RunScript(`add`, "func.js")
 	if err != nil {
 		t.Errorf("error not expected: %v", err)
 	}
 
 	iso := ctx.Isolate()
 	ctx2 := v8.NewContext(iso)
-	_, err = ctx2.CompileAndRun(`add`, "ctx2.js")
+	_, err = ctx2.RunScript(`add`, "ctx2.js")
 	if err == nil {
 		t.Error("error expected but was <nil>")
 	}
@@ -58,7 +58,7 @@ func TestJSExceptions(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ctx.CompileAndRun(tt.source, tt.origin)
+			_, err := ctx.RunScript(tt.source, tt.origin)
 			if err == nil {
 				t.Error("error expected but got <nil>")
 				return
@@ -105,7 +105,7 @@ func TestMemoryLeak(t *testing.T) {
 		ctx := v8.NewContext(iso)
 		obj := ctx.Global()
 		_ = obj.String()
-		_, _ = ctx.CompileAndRun("2", "")
+		_, _ = ctx.RunScript("2", "")
 		ctx.Close()
 	}
 	if n := iso.GetHeapStatistics().NumberOfNativeContexts; n >= 6000 {
@@ -131,7 +131,7 @@ func TestRegistryFromJSON(t *testing.T) {
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
 
-	v, err := ctx.CompileAndRun(`
+	v, err := ctx.RunScript(`
 		new Proxy({
 			"hello": "unknown"
 		}, {
@@ -157,10 +157,10 @@ func BenchmarkContext(b *testing.B) {
 	defer iso.Dispose()
 	for n := 0; n < b.N; n++ {
 		ctx := v8.NewContext(iso)
-		ctx.CompileAndRun(script, "main.js")
+		ctx.RunScript(script, "main.js")
 		str, _ := json.Marshal(makeObject())
 		cmd := fmt.Sprintf("process(%s)", str)
-		ctx.CompileAndRun(cmd, "cmd.js")
+		ctx.RunScript(cmd, "cmd.js")
 		ctx.Close()
 	}
 }
@@ -169,9 +169,9 @@ func ExampleContext() {
 	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	ctx.CompileAndRun("const add = (a, b) => a + b", "math.js")
-	ctx.CompileAndRun("const result = add(3, 4)", "main.js")
-	val, _ := ctx.CompileAndRun("result", "value.js")
+	ctx.RunScript("const add = (a, b) => a + b", "math.js")
+	ctx.RunScript("const result = add(3, 4)", "main.js")
+	val, _ := ctx.RunScript("result", "value.js")
 	fmt.Println(val)
 	// Output:
 	// 7
@@ -182,13 +182,13 @@ func ExampleContext_isolate() {
 	defer iso.Dispose()
 	ctx1 := v8.NewContext(iso)
 	defer ctx1.Close()
-	ctx1.CompileAndRun("const foo = 'bar'", "context_one.js")
-	val, _ := ctx1.CompileAndRun("foo", "foo.js")
+	ctx1.RunScript("const foo = 'bar'", "context_one.js")
+	val, _ := ctx1.RunScript("foo", "foo.js")
 	fmt.Println(val)
 
 	ctx2 := v8.NewContext(iso)
 	defer ctx2.Close()
-	_, err := ctx2.CompileAndRun("foo", "context_two.js")
+	_, err := ctx2.RunScript("foo", "context_two.js")
 	fmt.Println(err)
 	// Output:
 	// bar
@@ -202,7 +202,7 @@ func ExampleContext_globalTemplate() {
 	obj.Set("version", "v1.0.0")
 	ctx := v8.NewContext(iso, obj)
 	defer ctx.Close()
-	val, _ := ctx.CompileAndRun("version", "main.js")
+	val, _ := ctx.RunScript("version", "main.js")
 	fmt.Println(val)
 	// Output:
 	// v1.0.0

--- a/cpuprofile_test.go
+++ b/cpuprofile_test.go
@@ -24,7 +24,7 @@ func TestCPUProfile(t *testing.T) {
 	title := "cpuprofiletest"
 	cpuProfiler.StartProfiling(title)
 
-	_, err := ctx.CompileAndRun(profileScript, "script.js")
+	_, err := ctx.RunScript(profileScript, "script.js")
 	fatalIf(t, err)
 	val, err := ctx.Global().Get("start")
 	fatalIf(t, err)

--- a/cpuprofilenode_test.go
+++ b/cpuprofilenode_test.go
@@ -24,7 +24,7 @@ func TestCPUProfileNode(t *testing.T) {
 	title := "cpuprofilenodetest"
 	cpuProfiler.StartProfiling(title)
 
-	_, err := ctx.CompileAndRun(profileScript, "script.js")
+	_, err := ctx.RunScript(profileScript, "script.js")
 	fatalIf(t, err)
 	val, err := ctx.Global().Get("start")
 	fatalIf(t, err)

--- a/cpuprofiler_test.go
+++ b/cpuprofiler_test.go
@@ -58,7 +58,7 @@ func TestCPUProfiler(t *testing.T) {
 	title := "cpuprofilertest"
 	cpuProfiler.StartProfiling(title)
 
-	_, err := ctx.CompileAndRun(profileScript, "script.js")
+	_, err := ctx.RunScript(profileScript, "script.js")
 	fatalIf(t, err)
 	val, err := ctx.Global().Get("start")
 	fatalIf(t, err)

--- a/errors_test.go
+++ b/errors_test.go
@@ -66,8 +66,8 @@ func TestJSErrorOutput(t *testing.T) {
 	b;
 	`
 
-	ctx.CompileAndRun(math, "math.js")
-	_, err := ctx.CompileAndRun(main, "main.js")
+	ctx.RunScript(math, "math.js")
+	_, err := ctx.RunScript(main, "main.js")
 	if err == nil {
 		t.Error("expected error but got <nil>")
 		return

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -102,7 +102,7 @@ func TestFunctionCallbackInfoThis(t *testing.T) {
 	global.Set("foo", foo)
 
 	ctx := v8.NewContext(iso, global)
-	ctx.CompileAndRun("foo.bar()", "")
+	ctx.RunScript("foo.bar()", "")
 
 	v, _ := this.Get("name")
 	if v.String() != "foobar" {
@@ -121,7 +121,7 @@ func ExampleFunctionTemplate() {
 	global.Set("print", printfn, v8.ReadOnly)
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
-	ctx.CompileAndRun("print('foo', 'bar', 0, 1)", "")
+	ctx.RunScript("print('foo', 'bar', 0, 1)", "")
 	// Output:
 	// [foo bar 0 1]
 }
@@ -149,7 +149,7 @@ func ExampleFunctionTemplate_fetch() {
 
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
-	val, _ := ctx.CompileAndRun("fetch('https://rogchap.com/v8go')", "")
+	val, _ := ctx.RunScript("fetch('https://rogchap.com/v8go')", "")
 	prom, _ := val.AsPromise()
 
 	// wait for the promise to resolve

--- a/function_test.go
+++ b/function_test.go
@@ -17,7 +17,7 @@ func TestFunctionCall(t *testing.T) {
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
-	_, err := ctx.CompileAndRun("function add(a, b) { return a + b; }", "")
+	_, err := ctx.RunScript("function add(a, b) { return a + b; }", "")
 	fatalIf(t, err)
 	addValue, err := ctx.Global().Get("add")
 	fatalIf(t, err)
@@ -54,7 +54,7 @@ func TestFunctionCallToGoFunc(t *testing.T) {
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
 
-	val, err := ctx.CompileAndRun(`(a, b) => { print("foo"); }`, "")
+	val, err := ctx.RunScript(`(a, b) => { print("foo"); }`, "")
 	fatalIf(t, err)
 	fn, err := val.AsFunction()
 	fatalIf(t, err)
@@ -76,7 +76,7 @@ func TestFunctionCallWithObjectReceiver(t *testing.T) {
 	global := v8.NewObjectTemplate(iso)
 
 	ctx := v8.NewContext(iso, global)
-	val, err := ctx.CompileAndRun(`class Obj { constructor(input) { this.input = input } print() { return this.input.toString() } }; new Obj("some val")`, "")
+	val, err := ctx.RunScript(`class Obj { constructor(input) { this.input = input } print() { return this.input.toString() } }; new Obj("some val")`, "")
 	fatalIf(t, err)
 	obj, err := val.AsObject()
 	fatalIf(t, err)
@@ -100,7 +100,7 @@ func TestFunctionCallError(t *testing.T) {
 	defer iso.Dispose()
 	defer ctx.Close()
 
-	_, err := ctx.CompileAndRun("function throws() { throw 'error'; }", "script.js")
+	_, err := ctx.RunScript("function throws() { throw 'error'; }", "script.js")
 	fatalIf(t, err)
 	addValue, err := ctx.Global().Get("throws")
 	fatalIf(t, err)
@@ -123,7 +123,7 @@ func TestFunctionSourceMapUrl(t *testing.T) {
 	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	_, err := ctx.CompileAndRun("function add(a, b) { return a + b; }; //# sourceMappingURL=main.js.map", "main.js")
+	_, err := ctx.RunScript("function add(a, b) { return a + b; }; //# sourceMappingURL=main.js.map", "main.js")
 	fatalIf(t, err)
 	addValue, err := ctx.Global().Get("add")
 	fatalIf(t, err)
@@ -135,7 +135,7 @@ func TestFunctionSourceMapUrl(t *testing.T) {
 		t.Errorf("expected main.js.map, got %v", resultVal.String())
 	}
 
-	_, err = ctx.CompileAndRun("function sub(a, b) { return a - b; };", "")
+	_, err = ctx.RunScript("function sub(a, b) { return a - b; };", "")
 	fatalIf(t, err)
 	subValue, err := ctx.Global().Get("sub")
 	fatalIf(t, err)
@@ -184,7 +184,7 @@ func TestFunctionNewInstanceError(t *testing.T) {
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
-	_, err := ctx.CompileAndRun("function throws() { throw 'error'; }", "script.js")
+	_, err := ctx.RunScript("function throws() { throw 'error'; }", "script.js")
 	fatalIf(t, err)
 	throwsValue, err := ctx.Global().Get("throws")
 	fatalIf(t, err)

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -113,7 +113,7 @@ func TestGlobalObjectTemplate(t *testing.T) {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
 			ctx := v8.NewContext(iso, tt.global())
-			val, err := ctx.CompileAndRun(tt.source, "test.js")
+			val, err := ctx.RunScript(tt.source, "test.js")
 			if err != nil {
 				t.Fatalf("unexpected error runing script: %v", err)
 			}

--- a/object_test.go
+++ b/object_test.go
@@ -16,7 +16,7 @@ func TestObjectMethodCall(t *testing.T) {
 
 	ctx := v8.NewContext()
 	iso := ctx.Isolate()
-	val, _ := ctx.CompileAndRun(`class Obj { constructor(input) { this.input = input, this.prop = "" } print() { return this.input.toString() } }; new Obj("some val")`, "")
+	val, _ := ctx.RunScript(`class Obj { constructor(input) { this.input = input, this.prop = "" } print() { return this.input.toString() } }; new Obj("some val")`, "")
 	obj, _ := val.AsObject()
 	val, err := obj.MethodCall("print")
 	fatalIf(t, err)
@@ -28,7 +28,7 @@ func TestObjectMethodCall(t *testing.T) {
 		t.Errorf("expected an error, got none")
 	}
 
-	val, err = ctx.CompileAndRun(`class Obj2 { print(str) { return str.toString() }; get fails() { throw "error" } }; new Obj2()`, "")
+	val, err = ctx.RunScript(`class Obj2 { print(str) { return str.toString() }; get fails() { throw "error" } }; new Obj2()`, "")
 	fatalIf(t, err)
 	obj, _ = val.AsObject()
 	arg, _ := v8.NewValue(iso, "arg")
@@ -49,10 +49,10 @@ func TestObjectSet(t *testing.T) {
 	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	val, _ := ctx.CompileAndRun("const foo = {}; foo", "")
+	val, _ := ctx.RunScript("const foo = {}; foo", "")
 	obj, _ := val.AsObject()
 	obj.Set("bar", "baz")
-	baz, _ := ctx.CompileAndRun("foo.bar", "")
+	baz, _ := ctx.RunScript("foo.bar", "")
 	if baz.String() != "baz" {
 		t.Errorf("unexpected value: %q", baz)
 	}
@@ -68,7 +68,7 @@ func TestObjectSet(t *testing.T) {
 	if err := obj.SetIdx(10, t); err == nil {
 		t.Error("expected error but got <nil>")
 	}
-	if ten, _ := ctx.CompileAndRun("foo[10]", ""); ten.String() != "ten" {
+	if ten, _ := ctx.RunScript("foo[10]", ""); ten.String() != "ten" {
 		t.Errorf("unexpected value: %q", ten)
 	}
 }
@@ -126,7 +126,7 @@ func TestObjectGet(t *testing.T) {
 	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	val, _ := ctx.CompileAndRun("const foo = { bar: 'baz'}; foo", "")
+	val, _ := ctx.RunScript("const foo = { bar: 'baz'}; foo", "")
 	obj, _ := val.AsObject()
 	if bar, _ := obj.Get("bar"); bar.String() != "baz" {
 		t.Errorf("unexpected value: %q", bar)
@@ -134,7 +134,7 @@ func TestObjectGet(t *testing.T) {
 	if baz, _ := obj.Get("baz"); !baz.IsUndefined() {
 		t.Errorf("unexpected value: %q", baz)
 	}
-	ctx.CompileAndRun("foo[5] = 5", "")
+	ctx.RunScript("foo[5] = 5", "")
 	if five, _ := obj.GetIdx(5); five.Integer() != 5 {
 		t.Errorf("unexpected value: %q", five)
 	}
@@ -149,7 +149,7 @@ func TestObjectHas(t *testing.T) {
 	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	val, _ := ctx.CompileAndRun("const foo = {a: 1, '2': 2}; foo", "")
+	val, _ := ctx.RunScript("const foo = {a: 1, '2': 2}; foo", "")
 	obj, _ := val.AsObject()
 	if !obj.Has("a") {
 		t.Error("expected true, got false")
@@ -171,7 +171,7 @@ func TestObjectDelete(t *testing.T) {
 	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	val, _ := ctx.CompileAndRun("const foo = { bar: 'baz', '2': 2}; foo", "")
+	val, _ := ctx.RunScript("const foo = { bar: 'baz', '2': 2}; foo", "")
 	obj, _ := val.AsObject()
 	if !obj.Has("bar") {
 		t.Error("expected property to exist")
@@ -204,7 +204,7 @@ func ExampleObject_global() {
 	consoleObj, _ := console.NewInstance(ctx)
 
 	global.Set("console", consoleObj)
-	ctx.CompileAndRun("console.log('foo')", "")
+	ctx.RunScript("console.log('foo')", "")
 	// Output:
 	// foo
 }

--- a/script_compiler.go
+++ b/script_compiler.go
@@ -4,12 +4,15 @@
 
 package v8go
 
-type ScriptCompilerCachedData []byte
-
 type ScriptCompilerCompileOption int
 
 const (
-	ScriptCompilerCompileOptionNoCompileOptions = iota
-	ScriptCompilerCompileOptionConsumeCodeCache
-	ScriptCompilerCompileOptionEagerCompile
+	ScriptCompilerNoCompileOptions = iota
+	scriptCompilerConsumeCodeCache
+	ScriptCompilerEagerCompile
 )
+
+type ScriptCompilerCachedData struct {
+	Bytes    []byte
+	Rejected bool
+}

--- a/unbound_script.go
+++ b/unbound_script.go
@@ -1,0 +1,39 @@
+// Copyright 2021 the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package v8go
+
+// #include <stdlib.h>
+// #include "v8go.h"
+import "C"
+import "unsafe"
+
+type UnboundScript struct {
+	ptr C.UnboundScriptPtr
+	iso *Isolate
+}
+
+// Run will bind the unbound script to the provided context and run it.
+// If the context provided does not belong to the same isolate that the script
+// was compiled in, Run will panic.
+// If an error occurs, it will be of type `JSError`.
+func (u *UnboundScript) Run(ctx *Context) (*Value, error) {
+	if ctx.Isolate() != u.iso {
+		panic("attempted to run unbound script in a context that belongs to a different isolate")
+	}
+	rtn := C.UnboundScriptRun(ctx.ptr, u.ptr)
+	return valueResult(ctx, rtn)
+}
+
+// Create a code cache from the unbound script.
+func (u *UnboundScript) CreateCodeCache() *ScriptCompilerCachedData {
+	rtn := C.UnboundScriptCreateCodeCache(u.iso.ptr, u.ptr)
+
+	cachedData := &ScriptCompilerCachedData{
+		Bytes:    []byte(C.GoBytes(unsafe.Pointer(rtn.data), rtn.length)),
+		Rejected: int(rtn.rejected) == 1,
+	}
+	C.ScriptCompilerCachedDataDelete(rtn.ptr)
+	return cachedData
+}

--- a/unbound_script_test.go
+++ b/unbound_script_test.go
@@ -1,0 +1,47 @@
+// Copyright 2021 the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package v8go_test
+
+import (
+	"testing"
+
+	v8 "rogchap.com/v8go"
+)
+
+func TestUnboundScriptRun_OnlyInTheSameIsolate(t *testing.T) {
+	str := "function foo() { return 'bar'; }; foo()"
+	i1 := v8.NewIsolate()
+	defer i1.Dispose()
+
+	us, err := i1.CompileUnboundScript(str, "script.js", v8.CompileOptions{})
+	fatalIf(t, err)
+
+	c1 := v8.NewContext(i1)
+	defer c1.Close()
+
+	val, err := us.Run(c1)
+	fatalIf(t, err)
+	if val.String() != "bar" {
+		t.Fatalf("invalid value returned, expected bar got %v", val)
+	}
+
+	c2 := v8.NewContext(i1)
+	defer c2.Close()
+
+	val, err = us.Run(c2)
+	fatalIf(t, err)
+	if val.String() != "bar" {
+		t.Fatalf("invalid value returned, expected bar got %v", val)
+	}
+
+	i2 := v8.NewIsolate()
+	defer i2.Dispose()
+	i2c1 := v8.NewContext(i2)
+	defer i2c1.Close()
+
+	if recoverPanic(func() { us.Run(i2c1) }) == nil {
+		t.Error("expected panic running unbound script in a context belonging to a different isolate")
+	}
+}

--- a/v8go_test.go
+++ b/v8go_test.go
@@ -25,15 +25,15 @@ func TestSetFlag(t *testing.T) {
 	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	if _, err := ctx.CompileAndRun("a = 1", "default.js"); err != nil {
+	if _, err := ctx.RunScript("a = 1", "default.js"); err != nil {
 		t.Errorf("expected <nil> error, but got: %v", err)
 	}
 	v8.SetFlags("--use_strict")
-	if _, err := ctx.CompileAndRun("b = 1", "use_strict.js"); err == nil {
+	if _, err := ctx.RunScript("b = 1", "use_strict.js"); err == nil {
 		t.Error("expected error but got <nil>")
 	}
 	v8.SetFlags("--nouse_strict")
-	if _, err := ctx.CompileAndRun("c = 1", "nouse_strict.js"); err != nil {
+	if _, err := ctx.RunScript("c = 1", "nouse_strict.js"); err != nil {
 		t.Errorf("expected <nil> error, but got: %v", err)
 	}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -51,7 +51,7 @@ func TestValueFormatting(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			val, _ := ctx.CompileAndRun(tt.source, "test.js")
+			val, _ := ctx.RunScript(tt.source, "test.js")
 			if s := fmt.Sprintf("%v", val); s != tt.defaultVerb {
 				t.Errorf("incorrect format for %%v: %s", s)
 			}
@@ -88,7 +88,7 @@ func TestValueString(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			result, _ := ctx.CompileAndRun(tt.source, "test.js")
+			result, _ := ctx.RunScript(tt.source, "test.js")
 			str := result.String()
 			if str != tt.out {
 				t.Errorf("unexpected result: expected %q, got %q", tt.out, str)
@@ -117,7 +117,7 @@ func TestValueDetailString(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			result, _ := ctx.CompileAndRun(tt.source, "test.js")
+			result, _ := ctx.RunScript(tt.source, "test.js")
 			str := result.DetailString()
 			if str != tt.out {
 				t.Errorf("unexpected result: expected %q, got %q", tt.out, str)
@@ -152,7 +152,7 @@ func TestValueBoolean(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			val, _ := ctx.CompileAndRun(tt.source, "test.js")
+			val, _ := ctx.RunScript(tt.source, "test.js")
 			if b := val.Boolean(); b != tt.out {
 				t.Errorf("unexpected value: expected %v, got %v", tt.out, b)
 			}
@@ -180,7 +180,7 @@ func TestValueConstants(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 
-		val, err := ctx.CompileAndRun(tt.source, "test.js")
+		val, err := ctx.RunScript(tt.source, "test.js")
 		fatalIf(t, err)
 
 		if tt.value.SameValue(val) != tt.same {
@@ -216,7 +216,7 @@ func TestValueArrayIndex(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			val, _ := ctx.CompileAndRun(tt.source, "test.js")
+			val, _ := ctx.RunScript(tt.source, "test.js")
 			idx, ok := val.ArrayIndex()
 			if ok != tt.ok {
 				t.Errorf("unexpected ok: expected %v, got %v", tt.ok, ok)
@@ -259,7 +259,7 @@ func TestValueInt32(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			val, _ := ctx.CompileAndRun(tt.source, "test.js")
+			val, _ := ctx.RunScript(tt.source, "test.js")
 			if i32 := val.Int32(); i32 != tt.expected {
 				t.Errorf("unexpected value: expected %v, got %v", tt.expected, i32)
 			}
@@ -298,7 +298,7 @@ func TestValueInteger(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			val, _ := ctx.CompileAndRun(tt.source, "test.js")
+			val, _ := ctx.RunScript(tt.source, "test.js")
 			if i64 := val.Integer(); i64 != tt.expected {
 				t.Errorf("unexpected value: expected %v, got %v", tt.expected, i64)
 			}
@@ -335,7 +335,7 @@ func TestValueNumber(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			val, _ := ctx.CompileAndRun(tt.source, "test.js")
+			val, _ := ctx.RunScript(tt.source, "test.js")
 			f64 := val.Number()
 			if math.IsNaN(tt.expected) {
 				if !math.IsNaN(f64) {
@@ -368,7 +368,7 @@ func TestValueUint32(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			val, _ := ctx.CompileAndRun(tt.source, "test.js")
+			val, _ := ctx.RunScript(tt.source, "test.js")
 			if u32 := val.Uint32(); u32 != tt.expected {
 				t.Errorf("unexpected value: expected %v, got %v", tt.expected, u32)
 			}
@@ -402,7 +402,7 @@ func TestValueBigInt(t *testing.T) {
 			ctx := v8.NewContext(iso)
 			defer ctx.Close()
 
-			val, _ := ctx.CompileAndRun(tt.source, "test.js")
+			val, _ := ctx.RunScript(tt.source, "test.js")
 			b := val.BigInt()
 			if b == nil && tt.expected != nil {
 				t.Errorf("uexpected <nil> value")
@@ -426,7 +426,7 @@ func TestValueObject(t *testing.T) {
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
-	val, _ := ctx.CompileAndRun("1", "")
+	val, _ := ctx.RunScript("1", "")
 	if _, err := val.AsObject(); err == nil {
 		t.Error("Expected error but got <nil>")
 	}
@@ -442,11 +442,11 @@ func TestValuePromise(t *testing.T) {
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
-	val, _ := ctx.CompileAndRun("1", "")
+	val, _ := ctx.RunScript("1", "")
 	if _, err := val.AsPromise(); err == nil {
 		t.Error("Expected error but got <nil>")
 	}
-	if _, err := ctx.CompileAndRun("new Promise(()=>{})", ""); err != nil {
+	if _, err := ctx.RunScript("new Promise(()=>{})", ""); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -459,11 +459,11 @@ func TestValueFunction(t *testing.T) {
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
-	val, _ := ctx.CompileAndRun("1", "")
+	val, _ := ctx.RunScript("1", "")
 	if _, err := val.AsFunction(); err == nil {
 		t.Error("Expected error but got <nil>")
 	}
-	val, err := ctx.CompileAndRun("(a, b) => { return a + b; }", "")
+	val, err := ctx.RunScript("(a, b) => { return a + b; }", "")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -599,7 +599,7 @@ func TestValueIsXXX(t *testing.T) {
 			ctx := v8.NewContext(iso)
 			defer ctx.Close()
 
-			val, err := ctx.CompileAndRun(tt.source, "test.js")
+			val, err := ctx.RunScript(tt.source, "test.js")
 			if err != nil {
 				t.Fatalf("failed to run script: %v", err)
 			}
@@ -631,7 +631,7 @@ func TestValueMarshalJSON(t *testing.T) {
 		{
 			"object",
 			func(ctx *v8.Context) *v8.Value {
-				val, _ := ctx.CompileAndRun("let foo = {a:1, b:2}; foo", "test.js")
+				val, _ := ctx.RunScript("let foo = {a:1, b:2}; foo", "test.js")
 				return val
 			},
 			[]byte(`{"a":1,"b":2}`),
@@ -639,7 +639,7 @@ func TestValueMarshalJSON(t *testing.T) {
 		{
 			"objectFunc",
 			func(ctx *v8.Context) *v8.Value {
-				val, _ := ctx.CompileAndRun("let foo = {a:1, b:()=>{}}; foo", "test.js")
+				val, _ := ctx.RunScript("let foo = {a:1, b:()=>{}}; foo", "test.js")
 				return val
 			},
 			[]byte(`{"a":1}`),


### PR DESCRIPTION
Spiking again a proposed alternative to validate it's ease of use and correctness: https://github.com/rogchap/v8go/pull/206#issuecomment-961966404

```
Time taken to compile unbound script without cached data: 237 microseconds
Time taken to compile unbound script with cached data: 9 microseconds
```

```diff
@@ -15,6 +15,7 @@

 #include "_cgo_export.h"

+using namespace std::chrono;
 using namespace v8;

 auto default_platform = platform::NewDefaultPlatform();
@@ -234,10 +235,16 @@ RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso, const char* s, cons
   ScriptCompiler::CompileOptions option = static_cast<ScriptCompiler::CompileOptions>(opt);

   Local<UnboundScript> unbound_script;
+
+  auto start = high_resolution_clock::now();
   if (!ScriptCompiler::CompileUnboundScript(iso, &source, option).ToLocal(&unbound_script)) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
     return rtn;
   };
+  auto stop = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(stop - start);
+  std::cout << "Time taken to compile unbound script without cached data: "
+     << duration.count() << " microseconds" << std::endl;

   m_unboundScript* us = new m_unboundScript;
   us->iso = iso;
@@ -666,13 +673,18 @@ RtnValue CachedDataRun(ContextPtr ctx, CachedData* ptr, const char* source, cons
   ScriptCompiler::Source cached_source(src, script_origin, cached_data);

   Local<UnboundScript> unboundScript;
+  auto start = high_resolution_clock::now();
   if (!ScriptCompiler::CompileUnboundScript(iso, &cached_source, option).ToLocal(&unboundScript)) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
     return rtn;
   }
+  auto stop = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(stop - start);
+  std::cout << "Time taken to compile unbound script with cached data: "
+     << duration.count() << " microseconds" << std::endl;
   if (cached_data->rejected) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
-    rtn.error.msg = "cached data rejected";
+    rtn.error.msg = CopyString("cached data rejected");
     return rtn;
   }
```