### PR TITLE
SnapshotCreator API test v2

### DIFF
--- a/context.go
+++ b/context.go
@@ -71,7 +71,7 @@ func NewContext(opt ...ContextOption) *Context {
 	if createParams != nil && createParams.startupData != nil {
 		ctx = &Context{
 			ref: ref,
-			ptr: C.NewContextFromSnapShot(opts.iso.ptr, createParams.startupData.ptr.index, C.int(ref)),
+			ptr: C.NewContextFromSnapShot(opts.iso.ptr, createParams.startupData.index, C.int(ref)),
 			iso: opts.iso,
 		}
 	} else {

--- a/isolate.go
+++ b/isolate.go
@@ -76,9 +76,9 @@ func NewIsolate(opts ...createOptions) *Isolate {
 	var cOptions C.IsolateOptions
 
 	if params.startupData != nil {
-		p := C.CString(string(params.startupData.data))
-		cOptions.snapshot_blob_data = p
-		defer C.free(unsafe.Pointer(p))
+		// p := C.CString(string(params.startupData.data))
+		cOptions.snapshot_blob_data = params.startupData.data
+		// defer C.free(unsafe.Pointer(p))
 		cOptions.snapshot_blob_raw_size = params.startupData.raw_size
 	}
 

--- a/isolate.go
+++ b/isolate.go
@@ -73,18 +73,19 @@ func NewIsolate(opts ...createOptions) *Isolate {
 		opt(params)
 	}
 
-	var iso *Isolate
+	var cOptions C.IsolateOptions
+
 	if params.startupData != nil {
-		iso = &Isolate{
-			ptr:          C.NewIsolateWithCreateParams(params.startupData.ptr),
-			cbs:          make(map[int]FunctionCallback),
-			createParams: params,
-		}
-	} else {
-		iso = &Isolate{
-			ptr: C.NewIsolate(),
-			cbs: make(map[int]FunctionCallback),
-		}
+		p := C.CString(string(params.startupData.data))
+		cOptions.snapshot_blob_data = p
+		defer C.free(unsafe.Pointer(p))
+		cOptions.snapshot_blob_raw_size = params.startupData.raw_size
+	}
+
+	iso := &Isolate{
+		ptr:          C.NewIsolate(cOptions),
+		cbs:          make(map[int]FunctionCallback),
+		createParams: params,
 	}
 	iso.null = newValueNull(iso)
 	iso.undefined = newValueUndefined(iso)

--- a/isolate.go
+++ b/isolate.go
@@ -76,10 +76,7 @@ func NewIsolate(opts ...createOptions) *Isolate {
 	var cOptions C.IsolateOptions
 
 	if params.startupData != nil {
-		// p := C.CString(string(params.startupData.data))
-		cOptions.snapshot_blob_data = params.startupData.data
-		// defer C.free(unsafe.Pointer(p))
-		cOptions.snapshot_blob_raw_size = params.startupData.raw_size
+		cOptions.snapshot_blob = params.startupData.ptr
 	}
 
 	iso := &Isolate{

--- a/snapshot_creator.go
+++ b/snapshot_creator.go
@@ -9,6 +9,7 @@ package v8go
 import "C"
 import (
 	"errors"
+	"unsafe"
 )
 
 type FunctionCodeHandling int
@@ -19,14 +20,9 @@ const (
 )
 
 type StartupData struct {
-	ptr   *C.SnapshotBlob
-	index C.size_t
-}
-
-func (s *StartupData) Dispose() {
-	if s.ptr != nil {
-		C.SnapshotBlobDelete(s.ptr)
-	}
+	data     []byte
+	raw_size C.int
+	index    C.size_t
 }
 
 type SnapshotCreator struct {
@@ -75,7 +71,11 @@ func (s *SnapshotCreator) Create(functionCode FunctionCodeHandling) (*StartupDat
 	s.ctx.ptr = nil
 	s.iso.ptr = nil
 
-	return &StartupData{ptr: rtn, index: s.index}, nil
+	raw_size := rtn.raw_size
+	data := C.GoBytes(unsafe.Pointer(rtn.data), raw_size)
+	defer C.free(unsafe.Pointer(rtn.data))
+
+	return &StartupData{data: data, raw_size: raw_size, index: s.index}, nil
 }
 
 func (s *SnapshotCreator) Dispose() {

--- a/snapshot_creator.go
+++ b/snapshot_creator.go
@@ -53,7 +53,7 @@ func (s *SnapshotCreator) Create(source, origin string, functionCode FunctionCod
 	defer C.free(unsafe.Pointer(cSource))
 	defer C.free(unsafe.Pointer(cOrigin))
 
-	rtn := C.CreateSnapshot(s.ptr, cSource, cOrigin, C.int(functionCode))
+	rtn := C.CreateBlob(s.ptr, cSource, cOrigin, C.int(functionCode))
 
 	if rtn.blob == nil {
 		return nil, newJSError(rtn.error)

--- a/snapshot_creator.go
+++ b/snapshot_creator.go
@@ -9,7 +9,6 @@ package v8go
 import "C"
 import (
 	"errors"
-	"unsafe"
 )
 
 type FunctionCodeHandling int
@@ -20,7 +19,7 @@ const (
 )
 
 type StartupData struct {
-	data     []byte
+	data     *C.char
 	raw_size C.int
 	index    C.size_t
 }
@@ -72,10 +71,10 @@ func (s *SnapshotCreator) Create(functionCode FunctionCodeHandling) (*StartupDat
 	s.iso.ptr = nil
 
 	raw_size := rtn.raw_size
-	data := C.GoBytes(unsafe.Pointer(rtn.data), raw_size)
-	defer C.free(unsafe.Pointer(rtn.data))
+	// data := C.GoBytes(unsafe.Pointer(rtn.data), raw_size)
+	// defer C.free(unsafe.Pointer(rtn.data))
 
-	return &StartupData{data: data, raw_size: raw_size, index: s.index}, nil
+	return &StartupData{data: rtn.data, raw_size: raw_size, index: s.index}, nil
 }
 
 func (s *SnapshotCreator) Dispose() {

--- a/snapshot_creator.go
+++ b/snapshot_creator.go
@@ -19,9 +19,14 @@ const (
 )
 
 type StartupData struct {
-	data     *C.char
-	raw_size C.int
-	index    C.size_t
+	ptr   *C.RtnSnapshotBlob
+	index C.size_t
+}
+
+func (s *StartupData) Dispose() {
+	if s.ptr != nil {
+		C.SnapshotBlobDelete(s.ptr)
+	}
 }
 
 type SnapshotCreator struct {
@@ -70,11 +75,7 @@ func (s *SnapshotCreator) Create(functionCode FunctionCodeHandling) (*StartupDat
 	s.ctx.ptr = nil
 	s.iso.ptr = nil
 
-	raw_size := rtn.raw_size
-	// data := C.GoBytes(unsafe.Pointer(rtn.data), raw_size)
-	// defer C.free(unsafe.Pointer(rtn.data))
-
-	return &StartupData{data: rtn.data, raw_size: raw_size, index: s.index}, nil
+	return &StartupData{ptr: rtn, index: s.index}, nil
 }
 
 func (s *SnapshotCreator) Dispose() {

--- a/snapshot_creator.go
+++ b/snapshot_creator.go
@@ -49,8 +49,12 @@ func NewSnapshotCreator() *SnapshotCreator {
 	}
 }
 
-func (s *SnapshotCreator) GetIsolate() *Isolate {
-	return s.iso
+func (s *SnapshotCreator) GetIsolate() (*Isolate, error) {
+	if s.ptr == nil {
+		return nil, errors.New("v8go: Cannot get Isolate after creating the blob")
+	}
+
+	return s.iso, nil
 }
 
 func (s *SnapshotCreator) AddContext(ctx *Context) error {

--- a/snapshot_creator_test.go
+++ b/snapshot_creator_test.go
@@ -12,13 +12,15 @@ import (
 
 func TestCreateSnapshot(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
-	snapshotCreatorIso := snapshotCreator.GetIsolate()
+	snapshotCreatorIso, err := snapshotCreator.GetIsolate()
+	fatalIf(t, err)
+
 	snapshotCreatorCtx := v8.NewContext(snapshotCreatorIso)
 	defer snapshotCreatorCtx.Close()
 
 	snapshotCreatorCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
 	snapshotCreatorCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
-	err := snapshotCreator.AddContext(snapshotCreatorCtx)
+	err = snapshotCreator.AddContext(snapshotCreatorCtx)
 	fatalIf(t, err)
 
 	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
@@ -51,18 +53,24 @@ func TestCreateSnapshot(t *testing.T) {
 
 func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
-	snapshotCreatorIso := snapshotCreator.GetIsolate()
+	snapshotCreatorIso, err := snapshotCreator.GetIsolate()
+	fatalIf(t, err)
 	snapshotCreatorCtx := v8.NewContext(snapshotCreatorIso)
 	defer snapshotCreatorCtx.Close()
 
 	snapshotCreatorCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
 	snapshotCreatorCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
-	err := snapshotCreator.AddContext(snapshotCreatorCtx)
+	err = snapshotCreator.AddContext(snapshotCreatorCtx)
 	fatalIf(t, err)
 
 	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	fatalIf(t, err)
 	defer data.Dispose()
+
+	_, err = snapshotCreator.GetIsolate()
+	if err == nil {
+		t.Error("Getting Isolate should have fail")
+	}
 
 	err = snapshotCreator.AddContext(snapshotCreatorCtx)
 	if err == nil {

--- a/snapshot_creator_test.go
+++ b/snapshot_creator_test.go
@@ -98,36 +98,3 @@ func TestCreateSnapshotFailAndReuse(t *testing.T) {
 		t.Fatal("invalid val")
 	}
 }
-
-func TestCreateSnapshotWithIsolateOption(t *testing.T) {
-	iso1 := v8.NewIsolate()
-	defer iso1.Dispose()
-	snapshotCreator := v8.NewSnapshotCreator(v8.WithIsolate(iso1))
-
-	data, err := snapshotCreator.Create("function run() { return 1 };", "script.js", v8.FunctionCodeHandlingKlear)
-	fatalIf(t, err)
-
-	iso := v8.NewIsolate(v8.WithStartupData(data))
-	defer iso.Dispose()
-	defer data.Dispose()
-
-	ctx := v8.NewContext(iso)
-	defer ctx.Close()
-
-	runVal, err := ctx.Global().Get("run")
-	if err != nil {
-		panic(err)
-	}
-
-	fn, err := runVal.AsFunction()
-	if err != nil {
-		panic(err)
-	}
-	val, err := fn.Call(v8.Undefined(iso))
-	if err != nil {
-		panic(err)
-	}
-	if val.String() != "1" {
-		t.Fatal("invalid val")
-	}
-}

--- a/snapshot_creator_test.go
+++ b/snapshot_creator_test.go
@@ -13,12 +13,12 @@ import (
 func TestCreateSnapshot(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
 	snapshotCreatorIso := snapshotCreator.GetIsolate()
-	snapshotCreatoCtx := v8.NewContext(snapshotCreatorIso)
-	defer snapshotCreatoCtx.Close()
+	snapshotCreatorCtx := v8.NewContext(snapshotCreatorIso)
+	defer snapshotCreatorCtx.Close()
 
-	snapshotCreatoCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
-	snapshotCreatoCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
-	err := snapshotCreator.AddContext(snapshotCreatoCtx)
+	snapshotCreatorCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
+	snapshotCreatorCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
+	err := snapshotCreator.AddContext(snapshotCreatorCtx)
 	fatalIf(t, err)
 
 	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
@@ -52,19 +52,19 @@ func TestCreateSnapshot(t *testing.T) {
 func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
 	snapshotCreatorIso := snapshotCreator.GetIsolate()
-	snapshotCreatoCtx := v8.NewContext(snapshotCreatorIso)
-	defer snapshotCreatoCtx.Close()
+	snapshotCreatorCtx := v8.NewContext(snapshotCreatorIso)
+	defer snapshotCreatorCtx.Close()
 
-	snapshotCreatoCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
-	snapshotCreatoCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
-	err := snapshotCreator.AddContext(snapshotCreatoCtx)
+	snapshotCreatorCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
+	snapshotCreatorCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
+	err := snapshotCreator.AddContext(snapshotCreatorCtx)
 	fatalIf(t, err)
 
 	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	fatalIf(t, err)
 	defer data.Dispose()
 
-	err = snapshotCreator.AddContext(snapshotCreatoCtx)
+	err = snapshotCreator.AddContext(snapshotCreatorCtx)
 	if err == nil {
 		t.Error("Adding context should have fail")
 	}

--- a/snapshot_creator_test.go
+++ b/snapshot_creator_test.go
@@ -12,7 +12,13 @@ import (
 
 func TestCreateSnapshot(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
-	err := snapshotCreator.AddContext("function run() { return 1 };", "script.js")
+	snapshotCreatorIso := snapshotCreator.GetIsolate()
+	snapshotCreatoCtx := v8.NewContext(snapshotCreatorIso)
+	defer snapshotCreatoCtx.Close()
+
+	snapshotCreatoCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
+	snapshotCreatoCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
+	err := snapshotCreator.AddContext(snapshotCreatoCtx)
 	fatalIf(t, err)
 
 	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
@@ -38,68 +44,33 @@ func TestCreateSnapshot(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	if val.String() != "1" {
+	if val.String() != "7" {
 		t.Fatal("invalid val")
 	}
 }
 
 func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
+	snapshotCreatorIso := snapshotCreator.GetIsolate()
+	snapshotCreatoCtx := v8.NewContext(snapshotCreatorIso)
+	defer snapshotCreatoCtx.Close()
 
-	err := snapshotCreator.AddContext("function run() { return 1 };", "script.js")
+	snapshotCreatoCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
+	snapshotCreatoCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
+	err := snapshotCreator.AddContext(snapshotCreatoCtx)
 	fatalIf(t, err)
 
 	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	fatalIf(t, err)
 	defer data.Dispose()
+
+	err = snapshotCreator.AddContext(snapshotCreatoCtx)
+	if err == nil {
+		t.Error("Adding context should have fail")
+	}
 
 	_, err = snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	if err == nil {
 		t.Error("Creating snapshot should have fail")
-	}
-}
-
-func TestAddContextFail(t *testing.T) {
-	snapshotCreator := v8.NewSnapshotCreator()
-	defer snapshotCreator.Dispose()
-
-	err := snapshotCreator.AddContext("feuihyvfeuyfeu", "script.js")
-	if err == nil {
-		t.Error("add context should have fail")
-	}
-}
-
-func TestCreateSnapshotFailAndReuse(t *testing.T) {
-	snapshotCreator := v8.NewSnapshotCreator()
-	err := snapshotCreator.AddContext("feuihyvfeuyfeu", "script.js")
-	if err == nil {
-		t.Error("add context should have fail")
-	}
-	err = snapshotCreator.AddContext("function run() { return 1 };", "script.js")
-	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
-	fatalIf(t, err)
-
-	iso := v8.NewIsolate(v8.WithStartupData(data))
-	defer iso.Dispose()
-	defer data.Dispose()
-
-	ctx := v8.NewContext(iso)
-	defer ctx.Close()
-
-	runVal, err := ctx.Global().Get("run")
-	if err != nil {
-		panic(err)
-	}
-
-	fn, err := runVal.AsFunction()
-	if err != nil {
-		panic(err)
-	}
-	val, err := fn.Call(v8.Undefined(iso))
-	if err != nil {
-		panic(err)
-	}
-	if val.String() != "1" {
-		t.Fatal("invalid val")
 	}
 }

--- a/snapshot_creator_test.go
+++ b/snapshot_creator_test.go
@@ -23,6 +23,7 @@ func TestCreateSnapshot(t *testing.T) {
 
 	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	fatalIf(t, err)
+	defer data.Dispose()
 
 	iso := v8.NewIsolate(v8.WithStartupData(data))
 	defer iso.Dispose()
@@ -59,8 +60,9 @@ func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 	err := snapshotCreator.AddContext(snapshotCreatoCtx)
 	fatalIf(t, err)
 
-	_, err = snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
+	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	fatalIf(t, err)
+	defer data.Dispose()
 
 	err = snapshotCreator.AddContext(snapshotCreatoCtx)
 	if err == nil {

--- a/snapshot_creator_test.go
+++ b/snapshot_creator_test.go
@@ -23,7 +23,6 @@ func TestCreateSnapshot(t *testing.T) {
 
 	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	fatalIf(t, err)
-	defer data.Dispose()
 
 	iso := v8.NewIsolate(v8.WithStartupData(data))
 	defer iso.Dispose()
@@ -60,9 +59,8 @@ func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 	err := snapshotCreator.AddContext(snapshotCreatoCtx)
 	fatalIf(t, err)
 
-	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
+	_, err = snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	fatalIf(t, err)
-	defer data.Dispose()
 
 	err = snapshotCreator.AddContext(snapshotCreatoCtx)
 	if err == nil {

--- a/snapshot_creator_test.go
+++ b/snapshot_creator_test.go
@@ -12,13 +12,15 @@ import (
 
 func TestCreateSnapshot(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
-
-	data, err := snapshotCreator.Create("function run() { return 1 };", "script.js", v8.FunctionCodeHandlingKlear)
+	err := snapshotCreator.AddContext("function run() { return 1 };", "script.js")
 	fatalIf(t, err)
+
+	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
+	fatalIf(t, err)
+	defer data.Dispose()
 
 	iso := v8.NewIsolate(v8.WithStartupData(data))
 	defer iso.Dispose()
-	defer data.Dispose()
 
 	ctx := v8.NewContext(iso)
 	defer ctx.Close()
@@ -44,34 +46,37 @@ func TestCreateSnapshot(t *testing.T) {
 func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
 
-	data, err := snapshotCreator.Create("function run() { return 1 };", "script.js", v8.FunctionCodeHandlingKlear)
-	defer data.Dispose()
+	err := snapshotCreator.AddContext("function run() { return 1 };", "script.js")
 	fatalIf(t, err)
 
-	_, err = snapshotCreator.Create("function run2() { return 2 };", "script2.js", v8.FunctionCodeHandlingKlear)
+	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
+	fatalIf(t, err)
+	defer data.Dispose()
+
+	_, err = snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	if err == nil {
 		t.Error("Creating snapshot should have fail")
 	}
 }
 
-func TestCreateSnapshotFail(t *testing.T) {
+func TestAddContextFail(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
 	defer snapshotCreator.Dispose()
 
-	_, err := snapshotCreator.Create("uidygwuiwgduw", "script.js", v8.FunctionCodeHandlingKlear)
+	err := snapshotCreator.AddContext("feuihyvfeuyfeu", "script.js")
 	if err == nil {
-		t.Error("Creating snapshot should have fail")
+		t.Error("add context should have fail")
 	}
 }
 
 func TestCreateSnapshotFailAndReuse(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
-	_, err := snapshotCreator.Create("uidygwuiwgduw", "script.js", v8.FunctionCodeHandlingKlear)
+	err := snapshotCreator.AddContext("feuihyvfeuyfeu", "script.js")
 	if err == nil {
-		t.Error("Creating snapshot should have fail")
+		t.Error("add context should have fail")
 	}
-
-	data, err := snapshotCreator.Create("function run() { return 1 };", "script.js", v8.FunctionCodeHandlingKlear)
+	err = snapshotCreator.AddContext("function run() { return 1 };", "script.js")
+	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
 	fatalIf(t, err)
 
 	iso := v8.NewIsolate(v8.WithStartupData(data))

--- a/v8go.cc
+++ b/v8go.cc
@@ -306,7 +306,6 @@ size_t AddContext(SnapshotCreatorPtr snapshotCreator, ContextPtr ctx) {
   Local<Context> local_ctx = ctx->ptr.Get(iso);
   Context::Scope context_scope(local_ctx);
   return snapshotCreator->AddContext(local_ctx);
-  ;
 }
 
 RtnSnapshotBlob CreateBlob(SnapshotCreatorPtr snapshotCreator,
@@ -321,10 +320,10 @@ RtnSnapshotBlob CreateBlob(SnapshotCreatorPtr snapshotCreator,
 
   int length = startup_data.raw_size;
 
-  char* data = (char*)malloc(length);
-  memcpy(data, startup_data.data, length);
+  // char* data = (char*)malloc(length);
+  // memcpy(data, startup_data.data, length);
 
-  rtn.data = data;
+  rtn.data = startup_data.data;
   rtn.raw_size = length;
   delete snapshotCreator;
   return rtn;

--- a/v8go.cc
+++ b/v8go.cc
@@ -293,14 +293,9 @@ RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso,
 
 /********** SnapshotCreator **********/
 
-SnapshotCreatorPtr NewSnapshotCreator(SnapshotCreatorOptions options) {
-  if (options.iso) {
-    SnapshotCreator* creator = new SnapshotCreator(options.iso);
-    return creator;
-  } else {
-    SnapshotCreator* creator = new SnapshotCreator;
-    return creator;
-  }
+SnapshotCreatorPtr NewSnapshotCreator() {
+  SnapshotCreator* creator = new SnapshotCreator;
+  return creator;
 }
 
 void DeleteSnapshotCreator(SnapshotCreatorPtr snapshotCreator) {

--- a/v8go.cc
+++ b/v8go.cc
@@ -302,10 +302,10 @@ void DeleteSnapshotCreator(SnapshotCreatorPtr snapshotCreator) {
   delete snapshotCreator;
 }
 
-RtnSnapshotBlob CreateSnapshot(SnapshotCreatorPtr snapshotCreator,
-                               const char* source,
-                               const char* origin,
-                               int function_code_handling) {
+RtnSnapshotBlob CreateBlob(SnapshotCreatorPtr snapshotCreator,
+                           const char* source,
+                           const char* origin,
+                           int function_code_handling) {
   Isolate* iso = snapshotCreator->GetIsolate();
   size_t index;
   RtnSnapshotBlob rtn = {};

--- a/v8go.h
+++ b/v8go.h
@@ -79,7 +79,7 @@ typedef struct {
 typedef struct {
   const char* data;
   int raw_size;
-} SnapshotBlob;
+} RtnSnapshotBlob;
 
 typedef struct {
   SnapshotCreatorPtr creator;
@@ -90,6 +90,11 @@ typedef struct {
   ScriptCompilerCachedData cachedData;
   int compileOption;
 } CompileOptions;
+
+typedef struct {
+  const char* snapshot_blob_data;
+  int snapshot_blob_raw_size;
+} IsolateOptions;
 
 typedef struct {
   CpuProfilerPtr ptr;
@@ -145,21 +150,19 @@ typedef struct {
 } ValueBigInt;
 
 extern void Init();
-extern IsolatePtr NewIsolate();
-extern IsolatePtr NewIsolateWithCreateParams(SnapshotBlob* ptr);
+extern IsolatePtr NewIsolate(IsolateOptions opts);
 extern void IsolatePerformMicrotaskCheckpoint(IsolatePtr ptr);
 extern void IsolateDispose(IsolatePtr ptr);
 extern void IsolateTerminateExecution(IsolatePtr ptr);
 extern int IsolateIsExecutionTerminating(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
-extern void SnapshotBlobDelete(SnapshotBlob* ptr);
 extern RtnSnapshotCreator NewSnapshotCreator();
 extern void DeleteSnapshotCreator(SnapshotCreatorPtr snapshotCreator);
 extern size_t AddContext(SnapshotCreatorPtr snapshotCreator, ContextPtr ctx);
-extern SnapshotBlob* CreateBlob(SnapshotCreatorPtr snapshotCreator,
-                                ContextPtr ctx,
-                                int function_code_handling);
+extern RtnSnapshotBlob CreateBlob(SnapshotCreatorPtr snapshotCreator,
+                                  ContextPtr ctx,
+                                  int function_code_handling);
 
 extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);
 

--- a/v8go.h
+++ b/v8go.h
@@ -88,10 +88,6 @@ typedef struct {
 } RtnSnapshotBlob;
 
 typedef struct {
-  IsolatePtr iso;
-} SnapshotCreatorOptions;
-
-typedef struct {
   ScriptCompilerCachedData cachedData;
   int compileOption;
 } CompileOptions;
@@ -159,7 +155,7 @@ extern int IsolateIsExecutionTerminating(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
 extern void SnapshotBlobDelete(SnapshotBlob* ptr);
-extern SnapshotCreatorPtr NewSnapshotCreator(SnapshotCreatorOptions options);
+extern SnapshotCreatorPtr NewSnapshotCreator();
 extern void DeleteSnapshotCreator(SnapshotCreatorPtr snapshotCreator);
 extern RtnSnapshotBlob CreateSnapshot(SnapshotCreatorPtr snapshotCreator,
                                       const char* source,

--- a/v8go.h
+++ b/v8go.h
@@ -82,9 +82,9 @@ typedef struct {
 } SnapshotBlob;
 
 typedef struct {
-  size_t index;
-  RtnError error;
-} RtnSnapshotAddContext;
+  SnapshotCreatorPtr creator;
+  IsolatePtr iso;
+} RtnSnapshotCreator;
 
 typedef struct {
   ScriptCompilerCachedData cachedData;
@@ -154,12 +154,11 @@ extern int IsolateIsExecutionTerminating(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
 extern void SnapshotBlobDelete(SnapshotBlob* ptr);
-extern SnapshotCreatorPtr NewSnapshotCreator();
+extern RtnSnapshotCreator NewSnapshotCreator();
 extern void DeleteSnapshotCreator(SnapshotCreatorPtr snapshotCreator);
-extern RtnSnapshotAddContext AddContext(SnapshotCreatorPtr snapshotCreator,
-                                        const char* source,
-                                        const char* origin);
+extern size_t AddContext(SnapshotCreatorPtr snapshotCreator, ContextPtr ctx);
 extern SnapshotBlob* CreateBlob(SnapshotCreatorPtr snapshotCreator,
+                                ContextPtr ctx,
                                 int function_code_handling);
 
 extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);

--- a/v8go.h
+++ b/v8go.h
@@ -157,10 +157,10 @@ extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 extern void SnapshotBlobDelete(SnapshotBlob* ptr);
 extern SnapshotCreatorPtr NewSnapshotCreator();
 extern void DeleteSnapshotCreator(SnapshotCreatorPtr snapshotCreator);
-extern RtnSnapshotBlob CreateSnapshot(SnapshotCreatorPtr snapshotCreator,
-                                      const char* source,
-                                      const char* origin,
-                                      int function_code_handling);
+extern RtnSnapshotBlob CreateBlob(SnapshotCreatorPtr snapshotCreator,
+                                  const char* source,
+                                  const char* origin,
+                                  int function_code_handling);
 
 extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);
 

--- a/v8go.h
+++ b/v8go.h
@@ -92,8 +92,7 @@ typedef struct {
 } CompileOptions;
 
 typedef struct {
-  const char* snapshot_blob_data;
-  int snapshot_blob_raw_size;
+  RtnSnapshotBlob* snapshot_blob;
 } IsolateOptions;
 
 typedef struct {
@@ -157,12 +156,13 @@ extern void IsolateTerminateExecution(IsolatePtr ptr);
 extern int IsolateIsExecutionTerminating(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
+extern void SnapshotBlobDelete(RtnSnapshotBlob* ptr);
 extern RtnSnapshotCreator NewSnapshotCreator();
 extern void DeleteSnapshotCreator(SnapshotCreatorPtr snapshotCreator);
 extern size_t AddContext(SnapshotCreatorPtr snapshotCreator, ContextPtr ctx);
-extern RtnSnapshotBlob CreateBlob(SnapshotCreatorPtr snapshotCreator,
-                                  ContextPtr ctx,
-                                  int function_code_handling);
+extern RtnSnapshotBlob* CreateBlob(SnapshotCreatorPtr snapshotCreator,
+                                   ContextPtr ctx,
+                                   int function_code_handling);
 
 extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);
 

--- a/v8go.h
+++ b/v8go.h
@@ -79,13 +79,12 @@ typedef struct {
 typedef struct {
   const char* data;
   int raw_size;
-  size_t index;
 } SnapshotBlob;
 
 typedef struct {
-  SnapshotBlob* blob;
+  size_t index;
   RtnError error;
-} RtnSnapshotBlob;
+} RtnSnapshotAddContext;
 
 typedef struct {
   ScriptCompilerCachedData cachedData;
@@ -157,10 +156,11 @@ extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 extern void SnapshotBlobDelete(SnapshotBlob* ptr);
 extern SnapshotCreatorPtr NewSnapshotCreator();
 extern void DeleteSnapshotCreator(SnapshotCreatorPtr snapshotCreator);
-extern RtnSnapshotBlob CreateBlob(SnapshotCreatorPtr snapshotCreator,
-                                  const char* source,
-                                  const char* origin,
-                                  int function_code_handling);
+extern RtnSnapshotAddContext AddContext(SnapshotCreatorPtr snapshotCreator,
+                                        const char* source,
+                                        const char* origin);
+extern SnapshotBlob* CreateBlob(SnapshotCreatorPtr snapshotCreator,
+                                int function_code_handling);
 
 extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);
 


### PR DESCRIPTION
Change snapshot creator API to:

```go
func TestCreateSnapshot(t *testing.T) {
	snapshotCreator := v8.NewSnapshotCreator()
	snapshotCreatorIso := snapshotCreator.GetIsolate()
	snapshotCreatoCtx := v8.NewContext(snapshotCreatorIso)
	defer snapshotCreatoCtx.Close()

	snapshotCreatoCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
	snapshotCreatoCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
	snapshotCreator.AddContext(snapshotCreatoCtx)

	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
	fatalIf(t, err)
        defer data.Dispose()

	iso := v8.NewIsolate(v8.WithStartupData(data))
	defer iso.Dispose()

	ctx := v8.NewContext(iso)
	defer ctx.Close()

	runVal, err := ctx.Global().Get("run")
	if err != nil {
		panic(err)
	}

	fn, err := runVal.AsFunction()
	if err != nil {
		panic(err)
	}
	val, err := fn.Call(v8.Undefined(iso))
	if err != nil {
		panic(err)
	}
	if val.String() != "7" {
		t.Fatal("invalid val")
	}
}
```
