### PR TITLE
API v3 proposal

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -39,6 +39,22 @@ func TestContextExec(t *testing.T) {
 	}
 }
 
+func TestNewContextFromSnapShotErrorWhenIsolateHasNoStartupData(t *testing.T) {
+	t.Parallel()
+
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+
+	ctx, err := v8.NewContextFromSnapShot(iso, 1)
+
+	if ctx != nil {
+		t.Errorf("error expected nil context got: %+v", ctx)
+	}
+	if err == nil {
+		t.Error("error expected but was <nil>")
+	}
+}
+
 func TestJSExceptions(t *testing.T) {
 	t.Parallel()
 

--- a/snapshot_creator.go
+++ b/snapshot_creator.go
@@ -28,7 +28,6 @@ type SnapshotCreator struct {
 	ptr                 C.SnapshotCreatorPtr
 	iso                 *Isolate
 	defaultContextAdded bool
-	ctxs                []*Context
 }
 
 func NewSnapshotCreator() *SnapshotCreator {
@@ -71,7 +70,7 @@ func (s *SnapshotCreator) AddContext(ctx *Context) (int, error) {
 	}
 
 	index := C.AddContext(s.ptr, ctx.ptr)
-	s.ctxs = append(s.ctxs, ctx)
+	ctx.ptr = nil
 
 	return int(index), nil
 }
@@ -88,9 +87,6 @@ func (s *SnapshotCreator) Create(functionCode FunctionCodeHandling) (*StartupDat
 	rtn := C.CreateBlob(s.ptr, C.int(functionCode))
 
 	s.ptr = nil
-	for _, ctx := range s.ctxs {
-		ctx.ptr = nil
-	}
 	s.iso.ptr = nil
 
 	raw_size := rtn.raw_size

--- a/snapshot_creator_test.go
+++ b/snapshot_creator_test.go
@@ -20,7 +20,7 @@ func TestCreateSnapshot(t *testing.T) {
 
 	snapshotCreatorCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
 	snapshotCreatorCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
-	err = snapshotCreator.AddContext(snapshotCreatorCtx)
+	err = snapshotCreator.SetDeafultContext(snapshotCreatorCtx)
 	fatalIf(t, err)
 
 	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
@@ -50,6 +50,104 @@ func TestCreateSnapshot(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotAndAddExtraContext(t *testing.T) {
+	snapshotCreator := v8.NewSnapshotCreator()
+	snapshotCreatorIso, err := snapshotCreator.GetIsolate()
+	fatalIf(t, err)
+
+	snapshotCreatorCtx := v8.NewContext(snapshotCreatorIso)
+	defer snapshotCreatorCtx.Close()
+
+	snapshotCreatorCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
+	snapshotCreatorCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
+	err = snapshotCreator.SetDeafultContext(snapshotCreatorCtx)
+	fatalIf(t, err)
+
+	snapshotCreatorCtx2 := v8.NewContext(snapshotCreatorIso)
+	defer snapshotCreatorCtx2.Close()
+
+	snapshotCreatorCtx2.RunScript(`const multiply = (a, b) => a * b`, "add.js")
+	snapshotCreatorCtx2.RunScript(`function run() { return multiply(3, 4); }`, "main.js")
+	index, err := snapshotCreator.AddContext(snapshotCreatorCtx2)
+	fatalIf(t, err)
+
+	snapshotCreatorCtx3 := v8.NewContext(snapshotCreatorIso)
+	defer snapshotCreatorCtx3.Close()
+
+	snapshotCreatorCtx3.RunScript(`const div = (a, b) => a / b`, "add.js")
+	snapshotCreatorCtx3.RunScript(`function run() { return div(6, 2); }`, "main.js")
+	index2, err := snapshotCreator.AddContext(snapshotCreatorCtx3)
+	fatalIf(t, err)
+
+	data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
+	fatalIf(t, err)
+
+	iso := v8.NewIsolate(v8.WithStartupData(data))
+	defer iso.Dispose()
+
+	ctx, err := v8.NewContextFromSnapShot(iso, index)
+	fatalIf(t, err)
+	defer ctx.Close()
+
+	runVal, err := ctx.Global().Get("run")
+	if err != nil {
+		panic(err)
+	}
+
+	fn, err := runVal.AsFunction()
+	if err != nil {
+		panic(err)
+	}
+	val, err := fn.Call(v8.Undefined(iso))
+	if err != nil {
+		panic(err)
+	}
+	if val.String() != "12" {
+		t.Fatal("invalid val")
+	}
+
+	ctx, err = v8.NewContextFromSnapShot(iso, index2)
+	fatalIf(t, err)
+	defer ctx.Close()
+
+	runVal, err = ctx.Global().Get("run")
+	if err != nil {
+		panic(err)
+	}
+
+	fn, err = runVal.AsFunction()
+	if err != nil {
+		panic(err)
+	}
+	val, err = fn.Call(v8.Undefined(iso))
+	if err != nil {
+		panic(err)
+	}
+	if val.String() != "3" {
+		t.Fatal("invalid val")
+	}
+}
+
+func TestCreateSnapshotErrorAfterAddingMultipleDefaultContext(t *testing.T) {
+	snapshotCreator := v8.NewSnapshotCreator()
+	defer snapshotCreator.Dispose()
+	snapshotCreatorIso, err := snapshotCreator.GetIsolate()
+	fatalIf(t, err)
+	snapshotCreatorCtx := v8.NewContext(snapshotCreatorIso)
+
+	snapshotCreatorCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
+	snapshotCreatorCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
+	err = snapshotCreator.SetDeafultContext(snapshotCreatorCtx)
+	fatalIf(t, err)
+
+	err = snapshotCreator.SetDeafultContext(snapshotCreatorCtx)
+	defer snapshotCreatorCtx.Close()
+
+	if err == nil {
+		t.Error("Adding an extra default cointext show have fail")
+	}
+}
+
 func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
 	snapshotCreatorIso, err := snapshotCreator.GetIsolate()
@@ -59,7 +157,7 @@ func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 
 	snapshotCreatorCtx.RunScript(`const add = (a, b) => a + b`, "add.js")
 	snapshotCreatorCtx.RunScript(`function run() { return add(3, 4); }`, "main.js")
-	err = snapshotCreator.AddContext(snapshotCreatorCtx)
+	err = snapshotCreator.SetDeafultContext(snapshotCreatorCtx)
 	fatalIf(t, err)
 
 	_, err = snapshotCreator.Create(v8.FunctionCodeHandlingKlear)
@@ -70,7 +168,7 @@ func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 		t.Error("Getting Isolate should have fail")
 	}
 
-	err = snapshotCreator.AddContext(snapshotCreatorCtx)
+	_, err = snapshotCreator.AddContext(snapshotCreatorCtx)
 	if err == nil {
 		t.Error("Adding context should have fail")
 	}
@@ -81,7 +179,7 @@ func TestCreateSnapshotErrorAfterSuccessfullCreate(t *testing.T) {
 	}
 }
 
-func TestCreateSnapshotErrorIfNoContextIsAdded(t *testing.T) {
+func TestCreateSnapshotErrorIfNodefaultContextIsAdded(t *testing.T) {
 	snapshotCreator := v8.NewSnapshotCreator()
 	defer snapshotCreator.Dispose()
 

--- a/v8go.h
+++ b/v8go.h
@@ -160,9 +160,10 @@ extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 extern void SnapshotBlobDelete(RtnSnapshotBlob* ptr);
 extern RtnSnapshotCreator NewSnapshotCreator();
 extern void DeleteSnapshotCreator(SnapshotCreatorPtr snapshotCreator);
+extern void SetDefaultContext(SnapshotCreatorPtr snapshotCreator,
+                              ContextPtr ctx);
 extern size_t AddContext(SnapshotCreatorPtr snapshotCreator, ContextPtr ctx);
 extern RtnSnapshotBlob* CreateBlob(SnapshotCreatorPtr snapshotCreator,
-                                   ContextPtr ctx,
                                    int function_code_handling);
 
 extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);


### PR DESCRIPTION
After one last round of thoughts and code navigation on V8, I found a test that fully showed me how the API for heap snapshot is intended to be used. 

The test I'm talking about:

```c++
UNINITIALIZED_TEST(SnapshotCreatorMultipleContexts) {
  DisableAlwaysOpt();
  DisableEmbeddedBlobRefcounting();
  v8::StartupData blob;
  {
    v8::SnapshotCreator creator;
    v8::Isolate* isolate = creator.GetIsolate();
    {
      v8::HandleScope handle_scope(isolate);
      v8::Local<v8::Context> context = v8::Context::New(isolate);
      v8::Context::Scope context_scope(context);
      CompileRun("var f = function() { return 1; }");
      creator.SetDefaultContext(context);
    }
    {
      v8::HandleScope handle_scope(isolate);
      v8::Local<v8::Context> context = v8::Context::New(isolate);
      v8::Context::Scope context_scope(context);
      CompileRun("var f = function() { return 2; }");
      CHECK_EQ(0u, creator.AddContext(context));
    }
    {
      v8::HandleScope handle_scope(isolate);
      v8::Local<v8::Context> context = v8::Context::New(isolate);
      CHECK_EQ(1u, creator.AddContext(context));
    }
    blob =
        creator.CreateBlob(v8::SnapshotCreator::FunctionCodeHandling::kClear);
  }

  v8::Isolate::CreateParams params;
  params.snapshot_blob = &blob;
  params.array_buffer_allocator = CcTest::array_buffer_allocator();
  // Test-appropriate equivalent of v8::Isolate::New.
  v8::Isolate* isolate = TestSerializer::NewIsolate(params);
  {
    v8::Isolate::Scope isolate_scope(isolate);
    {
      v8::HandleScope handle_scope(isolate);
      v8::Local<v8::Context> context = v8::Context::New(isolate);
      v8::Context::Scope context_scope(context);
      ExpectInt32("f()", 1);
    }
    {
      v8::HandleScope handle_scope(isolate);
      v8::Local<v8::Context> context =
          v8::Context::FromSnapshot(isolate, 0).ToLocalChecked();
      v8::Context::Scope context_scope(context);
      ExpectInt32("f()", 2);
    }
    {
      v8::HandleScope handle_scope(isolate);
      v8::Local<v8::Context> context =
          v8::Context::FromSnapshot(isolate, 1).ToLocalChecked();
      v8::Context::Scope context_scope(context);
      ExpectUndefined("this.f");
    }
  }

  isolate->Dispose();
  delete[] blob.data;
  FreeCurrentEmbeddedBlob();
}
```

We can see that there are two important V8 functions `SetDefaultContext` and `AddContext`.

A single snapshot creator can have one default context but can have as many additional contexts as it wants. When we create an isolate with a `snapshot_blob` we can access the different snapshots using either `v8::Context::New` which will use the default context or `v8::Context::FromSnapshot` which you have to specify the snapshot index you want to use. 

Knowing this I believe we can mimic the same API in v8go.

We can allow developers to set a default context on the snapshot creator and if they don't want to have extra contexts they will be able to create new context by calling: 

```go 
err := snapshotCreator.SetDefaultContext(ctx)
data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)

iso := v8.NewIsolate(v8.WithStartupData(data))
defer iso.Dispose()

v8.NewContext(iso)
```

In the case the need to have multiple contexts associated with the snapshot we allow them to do it and they can use a different API to access it:

```go 
index, err := snapshotCreator.AddContext(ctx)
data, err := snapshotCreator.Create(v8.FunctionCodeHandlingKlear)

iso := v8.NewIsolate(v8.WithStartupData(data))
defer iso.Dispose()

v8.NewContextFromSnapshot(iso, index)
```

I believe this gives us the biggest flexibility in terms of the API since is very similar to the one in V8. 

The API  (`NewContextFromSnapshot`) for having multiple contexts with a snapshot creator would require them to keep track of the different indexes, but since every application using v8go is different we have to provide the most useful and flexible API. 